### PR TITLE
Ndrouin/fix sqlservernaming

### DIFF
--- a/infrastructure/terraform-stages-template.yml
+++ b/infrastructure/terraform-stages-template.yml
@@ -1,7 +1,7 @@
 parameters:
   displayName: Staging
   environment: stage
-  TerraformVersion: 0.12.17
+  TerraformVersion: 0.12.18
   TerraformVariables: ''
   TerraformBackendServiceConnection: Terraform
   TerraformEnvironmentServiceConnection: Terraform

--- a/infrastructure/terraform/sqlserver/main.tf
+++ b/infrastructure/terraform/sqlserver/main.tf
@@ -9,7 +9,7 @@ resource "random_password" "sql" {
 }
 
 resource "azurerm_sql_server" "example" {
-  name                         = "algattik01sqlserver"
+  name                         = "yourname01sqlserver${var.environment}"
   resource_group_name          = var.resource_group
   location                     = var.location
   version                      = "12.0"


### PR DESCRIPTION
Ensures unique name for the sql server, otherwise a conflict arises while running the scenario.  Terraform 0.12.17 was crashing when trying to run the 'Save plan text representation' when the plan include a resource replacement due to a name change: I updated to 0.12.18.